### PR TITLE
Reimplement Common Issues

### DIFF
--- a/bridget/__main__.py
+++ b/bridget/__main__.py
@@ -17,7 +17,7 @@ mongoengine.connect(
     port=int(
         getenv("DB_PORT")))
 
-from cogs import ChatGPT, Logging, Mod, NativeActionsListeners, Say, Snipe, Sync, Tags, TagsGroup, Unshorten, Timezones, Helper, FiltersGroup
+from cogs import ChatGPT, Logging, Mod, NativeActionsListeners, Say, Snipe, Sync, Tags, TagsGroup, Unshorten, Timezones, Helper, FiltersGroup, Issues, IssuesGroup
 from utils.startup_checks import checks
 from utils.config import cfg
 from utils import send_error, send_success
@@ -77,6 +77,8 @@ asyncio.run(bot.add_cog(Unshorten(bot)))
 asyncio.run(bot.add_cog(Timezones(bot)))
 asyncio.run(bot.add_cog(Helper(bot)))
 asyncio.run(bot.add_cog(FiltersGroup(bot)))
+asyncio.run(bot.add_cog(Issues(bot)))
+asyncio.run(bot.add_cog(IssuesGroup(bot)))
 
 # Error handler
 @bot.tree.error

--- a/bridget/cogs/__init__.py
+++ b/bridget/cogs/__init__.py
@@ -10,3 +10,4 @@ from .unshorten import Unshorten
 from .timezones import Timezones
 from .helper import Helper
 from .filters import FiltersGroup
+from .issues import Issues, IssuesGroup

--- a/bridget/cogs/issues.py
+++ b/bridget/cogs/issues.py
@@ -1,0 +1,344 @@
+import discord
+import re
+import asyncio
+
+from io import BytesIO
+from discord import Guild
+from discord.ext import commands
+from discord import app_commands
+from discord.embeds import Embed
+
+from model.issues import Issue
+from utils import Cog, send_error, send_success
+from utils.enums import PermissionLevel
+from utils.modals import IssueModal, EditIssueModal
+from utils.services import guild_service
+from utils.autocomplete import issues_autocomplete
+
+def prepare_issue_embed(issue: Issue) -> Embed:
+    """Given an issue object, prepare the appropriate embed for it
+
+    Parameters
+    ----------
+    issue : Issue
+        Issue object from database
+
+    Returns
+    -------
+    discord.Embed
+        The embed we want to send
+    """
+    embed = discord.Embed(title=issue.name)
+    embed.description = issue.content
+    embed.timestamp = issue.added_date
+    embed.color = discord.Color.blue()
+
+    if issue.image.read() is not None:
+        embed.set_image(url="attachment://image.gif" if issue.image.content_type ==
+                        "image/gif" else "attachment://image.png")
+    embed.set_footer(
+        text=f"Submitted by {issue.added_by_tag}")
+    return embed
+
+
+def prepare_issue_view(issue: Issue) -> discord.ui.View:
+    if not issue.button_links or issue.button_links is None:
+        return discord.utils.MISSING
+
+    view = discord.ui.View()
+    for label, link in issue.button_links:
+        # regex match emoji in label
+        custom_emojis = re.search(
+            r'<:\d+>|<:.+?:\d+>|<a:.+:\d+>|[\U00010000-\U0010ffff]', label)
+        if custom_emojis is not None:
+            emoji = custom_emojis.group(0).strip()
+            label = label.replace(emoji, '')
+            label = label.strip()
+        else:
+            emoji = None
+        view.add_item(
+            discord.ui.Button(
+                style=discord.ButtonStyle.link,
+                label=label,
+                url=link,
+                emoji=emoji))
+
+    return view
+
+async def refresh_common_issues(guild: Guild) -> None:
+    # this function deletes the list message and
+    # then resends the updated list.
+
+    channel = guild.get_channel(guild_service.get_guild().channel_common_issues)
+
+    # delete old list message
+    if guild_service.get_guild().issues_list_msg is not None:
+        for id in guild_service.get_guild().issues_list_msg:
+            try: # if someone accidentally deletes something
+                msg = await channel.fetch_message(id)
+                await msg.delete()
+            except:
+                pass
+
+    ids = []
+    embed = Embed(title="Table of Contents")
+    desc = ""
+    page = 0
+
+    for i, issue in enumerate(guild_service.get_guild().issues):
+        desc += f"{i+1}. [{issue.name}](https://discord.com/channels/{guild.id}/{channel.id}/{issue.message_id})\n"
+        if len(desc) > 3072:
+            embed.description = desc
+            page += 1
+            embed.set_footer(text=f"Page {page}")
+            msg = await channel.send(embed=embed)
+            embed = Embed(title="")
+            desc = ""
+            ids.append(msg.id)
+
+    if len(desc) > 0:
+        embed.description = desc
+        page += 1
+        embed.set_footer(text=f"Page {page}")
+        msg = await channel.send(embed=embed)
+        ids.append(msg.id)
+
+    guild_service.edit_issues_list(ids)
+
+async def do_reindex(ctx: discord.Interaction) -> None:
+    channel = ctx.guild.get_channel(guild_service.get_guild().channel_common_issues)
+
+    for issue in guild_service.get_guild().issues:
+        try:
+            msg = await channel.fetch_message(issue.message_id)
+            await msg.delete()
+        except:
+            pass
+
+        _file = issue.image.read()
+        if _file is not None:
+            _file = discord.File(
+                BytesIO(_file),
+                filename="image.gif" if issue.image.content_type == "image/gif" else "image.png")
+        else:
+            _file = discord.utils.MISSING
+
+        msg = await channel.send(file=_file or discord.utils.MISSING, embed=prepare_issue_embed(issue) or discord.utils.MISSING, view=prepare_issue_view(issue) or discord.utils.MISSING)
+        issue.message_id = msg.id
+
+        guild_service.edit_issue(issue)
+
+    # refresh common issue list
+    await refresh_common_issues(ctx.guild)
+    await ctx.followup.send(content="Reindexed!", ephemeral=True)
+
+
+class Issues(Cog):
+    @app_commands.autocomplete(name=issues_autocomplete)
+    @app_commands.command()
+    async def issue(self, ctx: discord.Interaction, name: str, user_to_mention: discord.Member = None) -> None:
+        """Send a common issue
+
+        Args:
+            ctx (discord.Interaction): Context
+            name (str): Name of the issue
+            user_to_mention (discord.Member, optional): User to mention. Defaults to None.
+        """
+
+        name = name.lower()
+        issue = guild_service.get_issue(name)
+
+        if issue is None:
+            raise commands.BadArgument("That issue does not exist.")
+
+        # run cooldown so tag can't be spammed
+        # bucket = self.tag_cooldown.get_bucket(tag.name)
+        # current = datetime.now().timestamp()
+        # ratelimit only if the invoker is not a moderator
+        # if bucket.update_rate_limit(current) and not (gatekeeper.has(ctx.guild, ctx.user, 5) or ctx.guild.get_role(guild_service.get_guild().role_sub_mod) in ctx.user.roles):
+        #    raise commands.BadArgument("That tag is on cooldown.")
+
+        # if the Issue has an image, add it to the embed
+        _file = issue.image.read()
+        if _file is not None:
+            _file = discord.File(
+                BytesIO(_file),
+                filename="image.gif" if issue.image.content_type == "image/gif" else "image.png")
+        else:
+            _file = discord.utils.MISSING
+
+        if user_to_mention is not None:
+            title = f"Hey {user_to_mention.mention}, have a look at this!"
+        else:
+            title = None
+
+        await ctx.response.send_message(content=title, embed=prepare_issue_embed(issue), view=prepare_issue_view(issue), file=_file)
+
+
+class IssuesGroup(Cog, commands.GroupCog, group_name="commonissue"):
+    @PermissionLevel.HELPER
+    @app_commands.command()
+    async def add(self, ctx: discord.Interaction, name: str, image: discord.Attachment = None) -> None:
+        """Add a common issue
+
+        Args:
+            ctx (discord.Interaction): Context
+            name (str): Name of the issue
+            image (discord.Attachment, optional): Issue image. Defaults to None.
+        """
+
+        if (guild_service.get_issue(name)) is not None:
+            raise commands.BadArgument("Issue with that name already exists.")
+
+        content_type = None
+        if image is not None:
+            content_type = image.content_type
+            if content_type not in [
+                "image/png",
+                "image/jpeg",
+                "image/gif",
+                    "image/webp"]:
+                raise commands.BadArgument("Attached file was not an image!")
+
+            if image.size > 8_000_000:
+                raise commands.BadArgument("That image is too big!")
+
+            image = await image.read()
+
+        modal = IssueModal(bot=self.bot, issue_name=name, author=ctx.user)
+        await ctx.response.send_modal(modal)
+        await modal.wait()
+
+        issue = modal.issue
+        if issue is None:
+            return
+
+        # did the user want to attach an image to this issue?
+        if image is not None:
+            issue.image.put(image, content_type=content_type)
+
+        _file = issue.image.read()
+        if _file is not None:
+            _file = discord.File(
+                BytesIO(_file),
+                filename="image.gif" if issue.image.content_type == "image/gif" else "image.png")
+
+
+        # send the issue in #common-issues channel
+        ci_channel = guild_service.get_guild().channel_common_issues
+        ci_msg = await ctx.guild.get_channel(ci_channel).send(file=_file or discord.utils.MISSING, embed=prepare_issue_embed(issue) or discord.utils.MISSING, view=prepare_issue_view(issue) or discord.utils.MISSING)
+        issue.message_id = ci_msg.id
+
+        # store issue in database
+        guild_service.add_issue(issue)
+
+        # refresh common issue list
+        await refresh_common_issues(ctx.guild)
+
+        followup = await ctx.followup.send("Added new issue!", file=_file or discord.utils.MISSING, embed=prepare_issue_embed(issue) or discord.utils.MISSING, view=prepare_issue_view(issue) or discord.utils.MISSING)
+        await asyncio.sleep(5)
+        await followup.delete()
+
+    @PermissionLevel.HELPER
+    @app_commands.autocomplete(name=issues_autocomplete)
+    @app_commands.command()
+    async def edit(self, ctx: discord.Interaction, name: str, image: discord.Attachment = None) -> None:
+        """Edit a common issue
+
+        Args:
+            ctx (discord.Interaction): Context
+            name (str): Name of the issue
+            image (discord.Attachment, optional): Issue image. Defaults to None.
+        """
+
+
+        issue = guild_service.get_issue(name)
+        if issue is None:
+            raise commands.BadArgument("That issue does not exist.")
+
+        content_type = None
+        if image is not None:
+            # ensure the attached file is an image
+            content_type = image.content_type
+            if image.size > 8_000_000:
+                raise commands.BadArgument("That image is too big!")
+
+            image = await image.read()
+            # save image bytes
+            if issue.image is not None:
+                issue.image.replace(image, content_type=content_type)
+            else:
+                issue.image.put(image, content_type=content_type)
+        else:
+            issue.image.delete()
+
+        modal = EditIssueModal(issue=issue, author=ctx.user)
+        await ctx.response.send_modal(modal)
+        await modal.wait()
+
+        if not modal.edited:
+            await send_error(ctx, "Issue edit was cancelled.", ephemeral=True)
+            return
+
+        issue = modal.issue
+
+        _file = issue.image.read()
+        if _file is not None:
+            _file = discord.File(
+                BytesIO(_file),
+                filename="image.gif" if issue.image.content_type == "image/gif" else "image.png")
+
+        # store issue in database
+        guild_service.edit_issue(issue)
+
+        # update the issue in #common-issues channel
+        ci_channel = guild_service.get_guild().channel_common_issues
+        ci_msg = await ctx.guild.get_channel(ci_channel).fetch_message(issue.message_id)
+        await ci_msg.edit(attachments=[_file] if _file else [], embed=prepare_issue_embed(issue) or discord.utils.MISSING, view=prepare_issue_view(issue) or discord.utils.MISSING)
+
+        followup = await ctx.followup.send("Edited issue!", file=_file or discord.utils.MISSING, embed=prepare_issue_embed(issue), view=prepare_issue_view(issue) or discord.utils.MISSING)
+        await asyncio.sleep(5)
+        await followup.delete()
+
+    @PermissionLevel.HELPER
+    @app_commands.autocomplete(name=issues_autocomplete)
+    @app_commands.command()
+    async def delete(self, ctx: discord.Interaction, name: str) -> None:
+        """Delete a common issue
+
+        Args:
+            ctx (discord.Interaction): Context
+            name (str): Name of the issue
+        """
+
+        issue = guild_service.get_issue(name)
+        if issue is None:
+            raise commands.BadArgument("That issue does not exist.")
+
+        if issue.image is not None:
+            issue.image.delete()
+
+        # remove the issue in #common-issues channel
+        ci_channel = guild_service.get_guild().channel_common_issues
+        ci_msg = await ctx.guild.get_channel(ci_channel).fetch_message(issue.message_id)
+        await ci_msg.delete()
+
+        # delete the issue from the database
+        guild_service.remove_issue(name)
+
+        # refresh common issue list
+        await refresh_common_issues(ctx.guild)
+
+        await send_success(ctx, f"Deleted issue `{issue.name}`.", delete_after=5)
+
+    @PermissionLevel.HELPER
+    @app_commands.command()
+    async def reindex(self, ctx: discord.Interaction) -> None:
+        """Reposts the issues in the common issues channel
+
+        Args:
+            ctx (discord.Interaction): Context
+        """
+
+        await ctx.response.defer(ephemeral=True, thinking=True)
+        ctx.client.loop.create_task(do_reindex(ctx))

--- a/bridget/model/__init__.py
+++ b/bridget/model/__init__.py
@@ -5,3 +5,4 @@ from .giveaway import *
 from .guild import *
 from .tag import *
 from .user import *
+from .issues import *

--- a/bridget/model/guild.py
+++ b/bridget/model/guild.py
@@ -1,6 +1,7 @@
 import mongoengine
 from .filterword import FilterWord
 from .tag import Tag
+from .issues import Issue
 
 
 class Guild(mongoengine.Document):
@@ -47,6 +48,8 @@ class Guild(mongoengine.Document):
     tags = mongoengine.EmbeddedDocumentListField(Tag, default=[])
     memes = mongoengine.EmbeddedDocumentListField(Tag, default=[])
     ban_today_spam_accounts = mongoengine.BooleanField(default=False)
+    issues = mongoengine.EmbeddedDocumentListField(Issue, default=[])
+    issues_list_msg = mongoengine.ListField(default=[])
 
     meta = {
         'db_alias': 'default',

--- a/bridget/model/issues.py
+++ b/bridget/model/issues.py
@@ -1,0 +1,13 @@
+import mongoengine
+from datetime import datetime
+
+
+class Issue(mongoengine.EmbeddedDocument):
+    name = mongoengine.StringField(required=True)
+    content = mongoengine.StringField(required=True)
+    added_by_tag = mongoengine.StringField()
+    added_by_id = mongoengine.IntField()
+    added_date = mongoengine.DateTimeField(default=datetime.now)
+    image = mongoengine.FileField(default=None)
+    button_links = mongoengine.ListField(default=[], required=False)
+    message_id = mongoengine.IntField()

--- a/bridget/utils/autocomplete.py
+++ b/bridget/utils/autocomplete.py
@@ -25,6 +25,12 @@ async def tags_autocomplete(_: discord.Interaction, current: str) -> List[app_co
     return [app_commands.Choice(name=tag, value=tag)
             for tag in tags if current.lower() in tag.lower()][:25]
 
+async def issues_autocomplete(_: discord.Interaction, current: str) -> List[app_commands.Choice[str]]:
+    issues = sorted([issue.name for issue in guild_service.get_guild().issues])
+    return [app_commands.Choice(name=issue, value=issue)
+            for issue in issues if current.lower() in issue.lower()][:25]
+
+
 async def filter_bypass_autocomplete(ctx: discord.Interaction, current: str) -> List[app_commands.Choice[int]]:
     # TODO: Real permission check for mod+
     if ctx.user.id != cfg.owner_id:

--- a/bridget/utils/menus.py
+++ b/bridget/utils/menus.py
@@ -92,10 +92,8 @@ class Menu(ui.View):
 
         if interaction is not None:  # we want to edit, due to button press
             await interaction.response.edit_message(embed=embed, view=self)
-        elif interaction.response.is_done():
-            await interaction.edit_original_message(embed=embed, view=self)
-        else:  # this is the first time we're posting this menu
-            await interaction.response.send_message(embed=embed, view=self, ephemeral=self.whisper)
+        elif self.ctx.response.is_done(): # i guess this fixes it, too lazy to test it - Jan
+            await self.ctx.response.edit_message(embed=embed, view=self)
 
     async def on_timeout(self) -> None:
         self.stopped = True

--- a/bridget/utils/menus.py
+++ b/bridget/utils/menus.py
@@ -46,7 +46,11 @@ class Menu(ui.View):
             self.remove_item(self.last)
 
     async def start(self) -> None:
-        await self.refresh_response_message(self.ctx)
+        embed = await self.generate_next_embed()
+        self.refresh_button_state()
+        await self.ctx.response.send_message(embed=embed, view=self, ephemeral=self.whisper)
+
+        #await self.refresh_response_message(self.ctx)
 
     async def generate_next_embed(self):
         if self.current_page in self.page_cache:
@@ -135,4 +139,4 @@ class Menu(ui.View):
             await self.refresh_response_message(interaction)
 
     def on_interaction_check(self, interaction: discord.Interaction) -> bool:
-        return interaction.user == self.ctx.author
+        return interaction.user == self.ctx.user

--- a/bridget/utils/modals.py
+++ b/bridget/utils/modals.py
@@ -1,7 +1,7 @@
 import re
 import discord
 
-from model import Tag, User
+from model import Tag, User, Issue
 
 class TagModal(discord.ui.Modal):
     def __init__(self, bot, tag_name, author: discord.Member) -> None:
@@ -328,6 +328,194 @@ class ReasonModal(discord.ui.Modal):
 
         self.reason = reason
         self.stop()
+        try:
+            await interaction.response.send_message()
+        except BaseException:
+            pass
+
+    async def send_error(self, interaction: discord.Interaction, error: str) -> None:
+        embed = discord.Embed(
+            title="An error occurred",
+            description=error,
+            color=discord.Color.red())
+        await interaction.response.send_message(embed=embed, ephemeral=True)
+
+
+class IssueModal(discord.ui.Modal):
+    def __init__(self, bot, issue_name, author: discord.Member) -> None:
+        self.bot = bot
+        self.issue_name = issue_name
+        self.author = author
+        self.issue = None
+
+        super().__init__(title=f"Add common issue {self.issue_name}")
+
+        self.add_item(
+            discord.ui.TextInput(
+                label="Body of the issue",
+                placeholder="Enter the body of the issue",
+                style=discord.TextStyle.long,
+            )
+        )
+
+        for i in range(2):
+            self.add_item(
+                discord.ui.TextInput(
+                    label=f"Button {(i%2)+1} name",
+                    placeholder="Enter a name for the button. You can also put an emoji at the start.",
+                    style=discord.TextStyle.short,
+                    required=False,
+                    max_length=80))
+            self.add_item(
+                discord.ui.TextInput(
+                    label=f"Button {(i%2)+1} link",
+                    placeholder="Enter a link for the button",
+                    style=discord.TextStyle.short,
+                    required=False
+                )
+            )
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        if interaction.user != self.author:
+            return
+
+        button_names = [child.value.strip() for child in self.children[1::2]
+                        if child.value is not None and len(child.value.strip()) > 0]
+        links = [child.value.strip() for child in self.children[2::2]
+                 if child.value is not None and len(child.value.strip()) > 0]
+
+        # make sure all links are valid URLs with regex
+        if not all(re.match(r'^(https|http)://.*', link) for link in links):
+            await self.send_error(interaction, "The links must be valid URLs!")
+            return
+
+        if len(button_names) != len(links):
+            await self.send_error(interaction, "All buttons must have labels and links!")
+            return
+
+        buttons = list(zip(button_names, links))
+        description = self.children[0].value
+        if not description:
+            await self.send_error(interaction, "Description is missing!")
+            return
+
+        for label in button_names:
+            custom_emojis = re.search(
+                r'<:\d+>|<:.+?:\d+>|<a:.+:\d+>|[\U00010000-\U0010ffff]', label)
+            if custom_emojis is not None:
+                emoji = custom_emojis.group(0).strip()
+                if not label.startswith(emoji):
+                    await self.send_error(interaction, "Emojis must be at the start of labels!")
+                    return
+                label = label.replace(emoji, '')
+                label = label.strip()
+                if not label:
+                    await self.send_error(interaction, "A button cannot just be an emoji!")
+                    return
+
+        # prepare issue data for database
+        issue = Issue()
+        issue.name = self.issue_name
+        issue.content = description
+        issue.added_by_id = self.author.id
+        issue.added_by_tag = str(self.author)
+        issue.button_links = buttons
+
+        self.issue = issue
+        self.stop()
+        try:
+            await interaction.response.send_message()
+        except BaseException:
+            pass
+
+    async def send_error(self, interaction: discord.Interaction, error: str) -> None:
+        embed = discord.Embed(
+            title="An error occurred",
+            description=error,
+            color=discord.Color.red())
+        await interaction.response.send_message(embed=embed, ephemeral=True)
+
+
+class EditIssueModal(discord.ui.Modal):
+    def __init__(self, issue: Issue, author: discord.Member) -> None:
+        self.issue = issue
+        self.author = author
+        self.edited = False
+
+        super().__init__(title=f"Edit common issue {self.issue.name}")
+
+        self.add_item(
+            discord.ui.TextInput(
+                label="Body of the issue",
+                placeholder="Enter the body of the issue",
+                style=discord.TextStyle.long,
+                default=issue.content
+            )
+        )
+
+        for i in range(2):
+            self.add_item(
+                discord.ui.TextInput(
+                    label=f"Button {(i%2)+1} name",
+                    placeholder="Enter a name for the button. You can also put an emoji at the start.",
+                    style=discord.TextStyle.short,
+                    required=False,
+                    max_length=80,
+                    default=self.issue.button_links[i][0] if len(
+                        self.issue.button_links) > i else None))
+            self.add_item(
+                discord.ui.TextInput(
+                    label=f"Button {(i%2)+1} link",
+                    placeholder="Enter a link for the button",
+                    style=discord.TextStyle.short,
+                    required=False,
+                    default=self.issue.button_links[i][1] if len(
+                        self.issue.button_links) > i else None))
+
+    async def on_submit(self, interaction: discord.Interaction) -> None:
+        if interaction.user != self.author:
+            return
+
+        button_names = [child.value.strip() for child in self.children[1::2]
+                        if child.value is not None and len(child.value.strip()) > 0]
+        links = [child.value.strip() for child in self.children[2::2]
+                 if child.value is not None and len(child.value.strip()) > 0]
+
+        # make sure all links are valid URLs with regex
+        if not all(re.match(r'^(https|http)://.*', link) for link in links):
+            await self.send_error(interaction, "The links must be valid URLs!")
+            return
+
+        if len(button_names) != len(links):
+            await self.send_error(interaction, "All buttons must have labels and links!")
+            return
+
+        buttons = list(zip(button_names, links))
+        description = self.children[0].value
+        if not description:
+            await self.send_error(interaction, "Description is missing!")
+            return
+
+        for label in button_names:
+            custom_emojis = re.search(
+                r'<:\d+>|<:.+?:\d+>|<a:.+:\d+>|[\U00010000-\U0010ffff]', label)
+            if custom_emojis is not None:
+                emoji = custom_emojis.group(0).strip()
+                if not label.startswith(emoji):
+                    await self.send_error(interaction, "Emojis must be at the start of labels!")
+                    return
+                label = label.replace(emoji, '')
+                label = label.strip()
+                if not label:
+                    await self.send_error(interaction, "A button cannot just be an emoji!")
+                    return
+
+        # prepare issue data for database
+        self.issue.content = description
+        self.issue.button_links = buttons
+        self.edited = True
+        self.stop()
+
         try:
             await interaction.response.send_message()
         except BaseException:

--- a/bridget/utils/services/guild_service.py
+++ b/bridget/utils/services/guild_service.py
@@ -1,4 +1,4 @@
-from model import Guild, Tag, FilterWord, Giveaway
+from model import Guild, Tag, Issue, FilterWord, Giveaway
 import os
 from typing import Optional
 
@@ -43,6 +43,37 @@ def get_tag(name: str):
     tag.use_count += 1
     edit_tag(tag)
     return tag
+
+
+def add_issue(issue: Issue) -> None:
+    Guild.objects(_id=guild_id).update_one(push__issues=issue)
+
+
+def remove_issue(issue: str):
+    return Guild.objects(
+        _id=guild_id).update_one(
+        pull__issues__name=Tag(
+            name=issue).name)
+
+
+def edit_issue(issue):
+    return Guild.objects(
+        _id=guild_id,
+        issues__name=issue.name).update_one(
+        set__issues__S=issue)
+
+
+def get_issue(name: str):
+    issue = Guild.objects.get(_id=guild_id).issues.filter(name=name).first()
+    if issue is None:
+        return
+    return issue
+
+
+def edit_issues_list(ids):
+    return Guild.objects(
+        _id=guild_id).update_one(
+        set__issues_list_msg=ids)
 
 
 def add_meme(meme: Tag) -> None:


### PR DESCRIPTION
I have reimplemented common issues!

This reimplementation does not follow the GIR way of doing this. I felt like giving common issues its own model makes more sense, given that tags and memes already have models.

- Adds `/issue` command
- Adds `/commonissue add/edit/remove` commands with its own modal (almost identical to the one used in tags)
- Adds `/commonissue reindex` command to resend all messages in the #common-issues channel.

Some stuff may be a bit hacky, though :trollface: 