### PR TITLE
chore: remove redundant PermissionsEnum.check()

### DIFF
--- a/bridget/cogs/helper.py
+++ b/bridget/cogs/helper.py
@@ -29,7 +29,9 @@ class Helper(Cog):
 
         # only OP and helpers can mark as solved
         if ctx.channel.owner_id != ctx.user.id:
-            PermissionLevel.HELPER.check(ctx)
+            if not self == ctx.user:
+                raise discord.app_commands.MissingPermissions(
+                    "You don't have permission to use this command.")
 
         await send_success(ctx, "Thread marked as solved!", ephemeral=False)
 

--- a/bridget/utils/enums.py
+++ b/bridget/utils/enums.py
@@ -6,6 +6,7 @@ from typing import List, Optional, Union
 
 from .services import guild_service
 from .config import cfg
+from .errors import MissingPermissionsError
 
 
 def rule_has_timeout(rule: AutoModRule) -> bool:
@@ -65,14 +66,9 @@ class PermissionLevel(IntEnum):
     def __add__(self, other) -> "PermissionLevel":
         return self.__class__(self.value + other)
 
-    def check(self, ctx: discord.Interaction) -> bool:
-        if not self == ctx.user:
-            raise discord.app_commands.MissingPermissions(
-                "You don't have permission to use this command.")
-        return True
 
     def __call__(self, command: discord.app_commands.Command) -> discord.app_commands.Command:
-        command.checks.append(self.check)
+        command.checks.append(lambda ctx: True if self == ctx.user else MissingPermissionsError.throw())
         return command
 
     def __hash__(self) -> int:

--- a/bridget/utils/errors.py
+++ b/bridget/utils/errors.py
@@ -1,0 +1,10 @@
+import discord
+
+_NOPERMSERRORMSG = "You don't have permission to use this command."
+
+class MissingPermissionsError(discord.app_commands.MissingPermissionsError):
+    def __init__(self) -> None:
+        super(_NOPERMSERRORMSG)
+    
+    def throw() -> None:
+        raise discord.app_commands.MissingPermissionsError(_NOPERMSERRORMSG)


### PR DESCRIPTION
This is to remove `PermissionsEnum.check()` as i deemed it to be unneeded. Although some may say you need to have it for errors, that is why i created a custom `MissingPermissionsError` which has a raise method and a preset message.
`MissingPermissionsError#throw()` is a class method so the following works:
```py
lambda ctx: True if self == ctx.user else MissingPermissionsError.throw()
```
but not
```py
lambda ctx: True if self == ctx.user else MissingPermissionsError().throw() # see the ()? Don't instantiate the error, just throw it
```
I created this error as there is no way to raise errors inside lambdas without a helper function. This class can be used outside of `enums.py` for generic missing permissions error (although not in here) 